### PR TITLE
Revert the lower bound for framework package import version range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <carbon.identity.authenticator.oidc.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.authenticator.oidc.imp.pkg.version.range>
         <!--Carbon Identity Framework Version-->
         <carbon.identity.framework.version>5.20.254</carbon.identity.framework.version>
-        <carbon.identity.framework.package.import.version.range>[5.20.254, 8.0.0)</carbon.identity.framework.package.import.version.range>
+        <carbon.identity.framework.package.import.version.range>[5.11.256, 8.0.0)</carbon.identity.framework.package.import.version.range>
         <carbon.identity.authenticator.utils.version>1.0.10</carbon.identity.authenticator.utils.version>
         <carbon.identity.authenticator.utils.package.import.version.range>[1.0.10,2.0.0)
         </carbon.identity.authenticator.utils.package.import.version.range>


### PR DESCRIPTION
## Purpose
- In version 1.0.9, the lowest version was changed. But its not required since the connector does not any new code from framework.
- So we can revert this to older lowest version to keep using the latest version of connector for 5.10 - latest